### PR TITLE
商品詳細表示

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -20,6 +20,10 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
+
   private
 
   def item_params

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -8,7 +8,7 @@ class Item < ApplicationRecord
   belongs_to_active_hash :prefecture
   belongs_to_active_hash :scheduled_delivery
 
-  # has_one :order
+  has_one :order
 
   validates :image, presence: true
   validates :name, presence: true
@@ -21,7 +21,7 @@ class Item < ApplicationRecord
   validates :price, presence: true,
                     numericality: { only_integer: true, greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999 }
 
-  # def sold_out?
-  # order.present?
-  # end
+  def sold_out?
+    order.present?
+  end
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -130,16 +130,16 @@
        <% if @items.present? %>
        <% @items.each do |item| %>
        <li class='list'>
-        <%# link_to item_path(item) do %>
+        <%= link_to item_path(item) do %>
          <div class='item-img-content'>
           <%= image_tag url_for(item.image), class: "item-img" %>
-          <%# if item.sold_out 
+          <% if item.sold_out? %>
            <div class='sold-out'>
             <span>Sold Out!!</span>
            </div>
-          <%# end %>
+          <% end %>
          </div>
-    
+        <% end %>
         <div class='item-info'>
           <h3 class='item-name'>
             <%= item.name %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,35 +4,37 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
+      <%= image_tag @item.image, class: "item-img" %>
+      <% if @item.order.present? %>
       <div class="sold-out">
         <span>Sold Out!!</span>
       </div>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
+      <% end %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ¥ <%= @item.price %>
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.shipping_fee_status.name %>
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+    <% if user_signed_in? && @item.order.nil? %>
+      <% if current_user.id == @item.user_id %>
+        
+    <%= link_to "商品の編集", edit_item_path(@item), class:"item-edit" %>
     <p class="or-text">or</p>
-    <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+    <%= link_to "削除", item_path(@item), data: { turbo_method: :delete, confirm: "削除しますか？" }, class:"item-delete" %>
 
 
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
+    <% else %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
+    <% end %>
+    <% end %>
 
 
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
@@ -44,27 +46,27 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%=  @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.shipping_fee_status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.scheduled_delivery.name %></td>
         </tr>
       </tbody>
     </table>
@@ -103,9 +105,9 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+  
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
+  
 </div>
 
 <%= render "shared/footer" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
 
-  resources :items, only: [:new, :create, :show] do
+  resources :items, only: [:new, :create, :show, :edit] do
     resources :purchases, only: [:index ,:create]
   end
 end


### PR DESCRIPTION
What
・商品詳細表示機能を実装しました。
・商品一覧ページからリンクをクリックすることで、商品の詳細情報が表示されるようにしました。
・詳細ページには商品名、価格、商品説明、出品者情報、商品画像、商品の状態、配送料の負担、発送元の地域、発送までの日数が表示されます。
・未ログインユーザーでも商品詳細ページを閲覧できるように設定しました。
Why
・ユーザーが各商品の詳細情報を確認できるようにするためです。
・購入を検討しているユーザーが、商品の状態や発送に関する情報を把握するために必要です。
・未ログイン状態でも商品情報を確認できるようにすることで、購入の意思決定を促すためです。

ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/61d3d4b33606d297b68955b81eeb391e
ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/ac7573ba39a8508653ae6751e58b74ad
 ログイン状態で、売却済み商品の商品詳細ページへ遷移した動画（現段階で商品購入機能の実装が済んでいる場合）
該当しない
ログアウト状態で、商品詳細ページへ遷移した動画
https://gyazo.com/fa129194c892c22f9fc24a272ce1010d

よろしくお願いします。