### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :edit, :update]
-  before_action :set_item, only: [:show, :edit, :update]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
   before_action :check_user, only: [:edit, :update]
   def index
     @items = Item.order('created_at DESC')
@@ -32,6 +32,14 @@ class ItemsController < ApplicationController
       redirect_to item_path(@item)
     else
       render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    if @item.destroy
+      redirect_to root_path
+    else
+      render :show, status: :unprocessable_entity
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
 
-  resources :items, only: [:new, :create, :show, :edit, :update] do
+  resources :items, only: [:new, :create, :show, :edit, :update, :destroy] do
     resources :purchases, only: [:index ,:create]
   end
 end


### PR DESCRIPTION
What
このプルリクエストでは、商品の削除機能を実装しました。商品詳細ページに削除ボタンを追加し、ユーザーが自分の商品を削除できるようにしました。商品削除後は、トップページにリダイレクトされ、削除された商品は一覧からも消えます。削除が実行されるのは、商品が出品者本人によって削除される場合に限定されます。

Why
商品の削除機能は、ユーザーが誤って出品した商品や売却済みの商品を削除するために必要です。また、セキュリティ上の理由から、出品者以外のユーザーが商品を削除できないようにするため、条件を設けています。この実装により、ユーザー体験の向上とアプリケーションの信頼性の確保が期待されます。

ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/fbfaff3de060bf994d9046de309f0c6c

よろしくお願いします。